### PR TITLE
When plugin folder is symlinked the CSS doesn't get included

### DIFF
--- a/class-debug-bar-cron.php
+++ b/class-debug-bar-cron.php
@@ -58,7 +58,7 @@ class ZT_Debug_Bar_Cron extends Debug_Bar_Panel {
 	 */
 	public function print_styles() {
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.dev' : '';
-		wp_enqueue_style( 'zt-debug-bar-cron', plugins_url( "css/debug-bar-cron$suffix.css", __FILE__ ), array(), '20120325' );
+		wp_enqueue_style( 'zt-debug-bar-cron', plugins_url( basename( dirname(__FILE__) ) . "/css/debug-bar-cron$suffix.css" ), array(), '20120325' );
 	}
 
 	/**


### PR DESCRIPTION
Currently when you symlink the Debug Bar Cron plugin into the plugins folder, the method of constructing the URL breaks. I often symlink in GitHub plugins as I can then have one instance managed by the GitHub App and symlink it into different projects on my dev machine.

This commit fixed the issue for me, and doesn't seem to break non-symlinked instance of the plugin.

I hope you find it useful.

Cheers,

Simon
