### PR TITLE
Handle nested arrays in cron values by using array_walk_recursive to output $info['args']

### DIFF
--- a/class-debug-bar-cron.php
+++ b/class-debug-bar-cron.php
@@ -217,9 +217,9 @@ class ZT_Debug_Bar_Cron extends Debug_Bar_Panel {
 					// Report the args
 					echo '<td valign="top">';
 					if ( ! empty( $info['args'] ) ) {
-						foreach ( $info['args'] as $key => $value ) {
+						array_walk_recursive( $info['args'], function( $value, $key ) {
 							echo wp_strip_all_tags( $key ) . ' => ' . wp_strip_all_tags( $value ) . '<br />';
-						}
+						} );
 					} else {
 						echo 'No Args';
 					}


### PR DESCRIPTION
Handle nested arrays in cron values by using array_walk_recursive to output $info['args']

Fixes the following notice:
Notice: Array to string conversion in wp-includes/formatting.php on line 3196

On a dev environment where notices are displayed, this causes the "Installed Plugins" page to appear blank (at least when xdebug is formatting the notice output).
