### PR TITLE
Cron args aren't always an array, which triggers a warning

### DIFF
--- a/class-debug-bar-cron.php
+++ b/class-debug-bar-cron.php
@@ -217,8 +217,12 @@ class ZT_Debug_Bar_Cron extends Debug_Bar_Panel {
 					// Report the args
 					echo '<td valign="top">';
 					if ( ! empty( $info['args'] ) ) {
-						foreach ( $info['args'] as $key => $value ) {
-							echo wp_strip_all_tags( $key ) . ' => ' . wp_strip_all_tags( $value ) . '<br />';
+						if ( is_array( $info['args'] ) ) {
+							foreach ( $info['args'] as $key => $value ) {
+								echo wp_strip_all_tags( $key ) . ' => ' . wp_strip_all_tags( $value ) . '<br />';
+							}
+						} else {
+							echo wp_strip_all_tags( $info['args'] );
 						}
 					} else {
 						echo 'No Args';


### PR DESCRIPTION
Cron args aren't always an array, which results in "Invalid argument supplied for foreach()" warnings.

Now, when non-array arguments are encountered, they're simply printed in the same manner that array arguments are.
