### PR TITLE
Allow intager arguments to be displayed

### DIFF
--- a/class-debug-bar-cron.php
+++ b/class-debug-bar-cron.php
@@ -245,7 +245,7 @@ class ZT_Debug_Bar_Cron extends Debug_Bar_Panel {
 	 * @return  void
 	 */
 	function display_cron_arguments( $key, $value, $depth = 0 ) {
-		if ( is_string( $value ) ) {
+		if ( is_string( $value ) || is_int( $value ) ) {
 			echo str_repeat( '&nbsp;', ( $depth * 2 ) ) . wp_strip_all_tags( $key ) . ' => ' . esc_html( $value ) . '<br />';
 		} else if ( is_array( $value ) ) {
 			if ( count( $value ) > 0 ) {


### PR DESCRIPTION
Currently if the value of an argument passed to cron is an integor, it isn't displayed.  This means causes the core publish_future_post event to not display the post that we are supposed to publish.
