### PR TITLE
Updated Core cron events list based on WP 4.0

### DIFF
--- a/class-debug-bar-cron.php
+++ b/class-debug-bar-cron.php
@@ -138,15 +138,16 @@ class ZT_Debug_Bar_Cron extends Debug_Bar_Panel {
 		// Lists all crons that are defined in WP Core
 		$core_cron_hooks = array(
 			'wp_scheduled_delete',
+			'wp_scheduled_auto_draft_delete',
+			'update_network_counts',
 			'upgrader_scheduled_cleanup',
 			'importer_scheduled_cleanup',
 			'publish_future_post',
-			'akismet_schedule_cron_recheck',
-			'akismet_scheduled_delete',
 			'do_pings',
 			'wp_version_check',
 			'wp_update_plugins',
-			'wp_update_themes'
+			'wp_update_themes',
+			'wp_maybe_auto_update',
 		);
 
 		// Sort and count crons

--- a/readme.txt
+++ b/readme.txt
@@ -42,6 +42,10 @@ Yes
 
 == Changelog ==
 
+= Trunk =
+
+* Updated Core cron events list - props [Jrf](http://profiles.wordpress.org/jrf).
+
 = 0.1.3 =
 
 * Fixed 'Array to string conversion' error when Cron job arguments are in a multi-dimensional array - props [Jrf](http://profiles.wordpress.org/jrf), [ethitter](http://profiles.wordpress.org/ethitter), and [mintindeed](http://profiles.wordpress.org/mintindeed).

--- a/readme.txt
+++ b/readme.txt
@@ -42,10 +42,6 @@ Yes
 
 == Changelog ==
 
-= Trunk =
-
-* Updated Core cron events list - props [Jrf](http://profiles.wordpress.org/jrf).
-
 = 0.1.3 =
 
 * Fixed 'Array to string conversion' error when Cron job arguments are in a multi-dimensional array - props [Jrf](http://profiles.wordpress.org/jrf), [ethitter](http://profiles.wordpress.org/ethitter), and [mintindeed](http://profiles.wordpress.org/mintindeed).


### PR DESCRIPTION
And removed the Akismet events from the core list as it's a plugin and not part of core.