### PR TITLE
Allow for localization of the plugin.

### DIFF
--- a/class-debug-bar-cron.php
+++ b/class-debug-bar-cron.php
@@ -40,6 +40,7 @@ class ZT_Debug_Bar_Cron extends Debug_Bar_Panel {
 	 */
 	private $_doing_cron = 'No';
 
+
 	/**
 	 * Give the panel a title and set the enqueues.
 	 *
@@ -94,7 +95,7 @@ class ZT_Debug_Bar_Cron extends Debug_Bar_Panel {
 		echo '<div class="debug-bar-cron">';
 		echo '<h2><span>' . __( 'Total Events', 'zt-debug-bar-cron' ) . ':</span>' . (int) $this->_total_crons . '</h2>';
 		echo '<h2><span>' . __( 'Doing Cron', 'zt-debug-bar-cron' ) . ':</span>' . $this->_doing_cron . '</h2>';
-		echo '<h2 class="times' . esc_attr( $times_class ) . '"><span>' . __( 'Next Event', 'zt-debug-bar-cron' ) . ':</span>' . $time_next_cron . '<br />' . $unix_time_next_cron . '<br />' . $human_time_next_cron . $this->display_past_time( $unix_time_next_cron ) . '</h2>';
+		echo '<h2 class="times' . esc_attr( $times_class ) . '"><span>' . __( 'Next Event', 'zt-debug-bar-cron' ) . ':</span>' . $time_next_cron . '<br />' . $unix_time_next_cron . '<br />' . $this->display_past_time( $human_time_next_cron, $unix_time_next_cron ) . '</h2>';
 		echo '<h2><span>' . __( 'Current Time', 'zt-debug-bar-cron' ) . ':</span>' . date( 'H:i:s' ) . '</h2>';
 		echo '<div class="clear"></div>';
 
@@ -194,7 +195,7 @@ class ZT_Debug_Bar_Cron extends Debug_Bar_Panel {
 				$times_class = time() > $time && 'No' == $this->_doing_cron ? ' class="past"' : '';
 
 				echo '<tr>';
-				echo '<td' . $times_class . '>' . date( 'Y-m-d H:i:s', $time ) . '<br />' . $time . '<br />' . human_time_diff( $time ) . $this->display_past_time( $time ) . '</td>';
+				echo '<td' . $times_class . '>' . date( 'Y-m-d H:i:s', $time ) . '<br />' . $time . '<br />' . $this->display_past_time( human_time_diff( $time ), $time ) . '</td>';
 				echo '<td>' . wp_strip_all_tags( $hook ) . '</td>';
 
 				foreach ( $data as $hash => $info ) {
@@ -203,17 +204,20 @@ class ZT_Debug_Bar_Cron extends Debug_Bar_Panel {
 					if ( $info['schedule'] )
 						echo wp_strip_all_tags( $info['schedule'] );
 					else
-						echo 'Single Event';
+						echo esc_html__( 'Single Event', 'zt-debug-bar-cron' );
 					echo '</td>';
 
 					// Report the interval
 					echo '<td>';
 					if ( isset( $info['interval'] ) ) {
-						echo wp_strip_all_tags( $info['interval'] ) . 's<br />';
-						echo $info['interval'] / 60 . 'm<br />';
-						echo $info['interval'] / ( 60  * 60 ). 'h';
+						/* TRANSLATORS: %s is number of seconds. */
+						printf( esc_html__( '%ss', 'zt-debug-bar-cron' ) . '<br />', wp_strip_all_tags( $info['interval'] ) );
+						/* TRANSLATORS: %s is number of minutes. */
+						printf( esc_html__( '%sm', 'zt-debug-bar-cron' ) . '<br />', ( wp_strip_all_tags( $info['interval'] ) / 60 ) );
+						/* TRANSLATORS: %s is number of hours. */
+						printf( esc_html__( '%sh', 'zt-debug-bar-cron' ), ( wp_strip_all_tags( $info['interval'] ) / ( 60 * 60 ) ) );
 					} else {
-						echo 'Single Event';
+						echo esc_html__( 'Single Event', 'zt-debug-bar-cron' );
 					}
 					echo '</td>';
 
@@ -226,7 +230,7 @@ class ZT_Debug_Bar_Cron extends Debug_Bar_Panel {
 					} else if ( is_string( $info['args'] ) && $info['args'] !== '' ) {
 						echo esc_html( $info['args'] );
 					} else {
-						echo 'No Args';
+						echo esc_html__( 'No Args', 'zt-debug-bar-cron' );
 					}
 					echo '</td>';
 				}
@@ -260,7 +264,7 @@ class ZT_Debug_Bar_Cron extends Debug_Bar_Panel {
 				}
 				echo str_repeat( '&nbsp;', ( ( $depth - 1 ) * 2 ) ) . ')';
 			} else {
-				echo 'Empty Array';
+				echo esc_html( 'Empty Array', 'zt-debug-bar-cron' );
 			}
 		}
 	}
@@ -296,12 +300,19 @@ class ZT_Debug_Bar_Cron extends Debug_Bar_Panel {
 	}
 
 	/**
-	 * Compares time with current time and outputs 'ago' if current time is greater that even time.
+	 * Compares time with current time and adds ' ago' if current time is greater than event time.
 	 *
-	 * @param   int     $time   Unix time of event.
+	 * @param string $human_time Human readable time difference.
+	 * @param int    $time       Unix time of event.
+	 *
 	 * @return  string
 	 */
-	private function display_past_time( $time ) {
-		return time() > $time ? ' ' . __( 'ago', 'zt-debug-bar-cron' ) : '';
+	private function display_past_time( $human_time, $time ) {
+		if ( time() > $time ) {
+			/* TRANSLATORS: %s is a human readable time difference. */
+			return sprintf( esc_html__( '%s ago', 'zt-debug-bar-cron' ), $human_time );
+		} else {
+			return $human_time;
+		}
 	}
 }

--- a/class-debug-bar-cron.php
+++ b/class-debug-bar-cron.php
@@ -46,7 +46,8 @@ class ZT_Debug_Bar_Cron extends Debug_Bar_Panel {
 	 * @return void
 	 */
 	public function init() {
-		$this->title( __( 'Cron', 'debug-bar' ) );
+		load_plugin_textdomain( 'zt-debug-bar-cron', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+		$this->title( __( 'Cron', 'zt-debug-bar-cron' ) );
 		add_action( 'wp_print_styles', array( $this, 'print_styles' ) );
 		add_action( 'admin_print_styles', array( $this, 'print_styles' ) );
 	}

--- a/languages/zt-debug-bar-cron.pot
+++ b/languages/zt-debug-bar-cron.pot
@@ -1,0 +1,157 @@
+#, fuzzy
+msgid ""
+msgstr ""
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"Project-Id-Version: Debug Bar Cron\n"
+"POT-Creation-Date: 2015-12-07 07:04+0100\n"
+"PO-Revision-Date: 2015-12-07 02:34+0100\n"
+"Last-Translator: Juliette Reinders Folmer <wpplugins_nospam@adviesenzo.nl>\n"
+"Language-Team: Juliette Reinders Folmer <wpplugins_nospam@adviesenzo.nl>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.5\n"
+"X-Poedit-Basepath: ..\n"
+"X-Poedit-WPHeader: debug-bar-cron.php\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-KeywordsList: __;_e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_attr__;"
+"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;_n_noop:1,2;"
+"_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
+"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-SearchPathExcluded-0: *.js\n"
+
+#: class-debug-bar-cron.php:51
+msgid "Cron"
+msgstr ""
+
+#: class-debug-bar-cron.php:83
+msgid "Yes"
+msgstr ""
+
+#: class-debug-bar-cron.php:83
+msgid "No"
+msgstr ""
+
+#: class-debug-bar-cron.php:96
+msgid "Total Events"
+msgstr ""
+
+#: class-debug-bar-cron.php:97
+msgid "Doing Cron"
+msgstr ""
+
+#: class-debug-bar-cron.php:98
+msgid "Next Event"
+msgstr ""
+
+#: class-debug-bar-cron.php:99
+msgid "Current Time"
+msgstr ""
+
+#: class-debug-bar-cron.php:102
+msgid "Custom Events"
+msgstr ""
+
+#: class-debug-bar-cron.php:107
+msgid "No Custom Events scheduled."
+msgstr ""
+
+#: class-debug-bar-cron.php:109
+msgid "Schedules"
+msgstr ""
+
+#: class-debug-bar-cron.php:113
+msgid "Core Events"
+msgstr ""
+
+#: class-debug-bar-cron.php:118
+msgid "No Core Events scheduled."
+msgstr ""
+
+#: class-debug-bar-cron.php:184
+msgid "Next Execution"
+msgstr ""
+
+#: class-debug-bar-cron.php:185
+msgid "Hook"
+msgstr ""
+
+#: class-debug-bar-cron.php:186 class-debug-bar-cron.php:280
+msgid "Interval Hook"
+msgstr ""
+
+#: class-debug-bar-cron.php:187
+msgid "Interval Value"
+msgstr ""
+
+#: class-debug-bar-cron.php:188
+msgid "Args"
+msgstr ""
+
+#: class-debug-bar-cron.php:207 class-debug-bar-cron.php:220
+msgid "Single Event"
+msgstr ""
+
+#. TRANSLATORS: %s is number of seconds.
+#: class-debug-bar-cron.php:214
+#, php-format
+msgid "%ss"
+msgstr ""
+
+#. TRANSLATORS: %s is number of minutes.
+#: class-debug-bar-cron.php:216
+#, php-format
+msgid "%sm"
+msgstr ""
+
+#. TRANSLATORS: %s is number of hours.
+#: class-debug-bar-cron.php:218
+#, php-format
+msgid "%sh"
+msgstr ""
+
+#: class-debug-bar-cron.php:233
+msgid "No Args"
+msgstr ""
+
+#: class-debug-bar-cron.php:281
+msgid "Interval (S)"
+msgstr ""
+
+#: class-debug-bar-cron.php:282
+msgid "Interval (M)"
+msgstr ""
+
+#: class-debug-bar-cron.php:283
+msgid "Interval (H)"
+msgstr ""
+
+#: class-debug-bar-cron.php:284
+msgid "Display Name"
+msgstr ""
+
+#. TRANSLATORS: %s is a human readable time difference.
+#: class-debug-bar-cron.php:313
+#, php-format
+msgid "%s ago"
+msgstr ""
+
+#. Plugin Name of the plugin/theme
+msgid "Debug Bar Cron"
+msgstr ""
+
+#. Plugin URI of the plugin/theme
+msgid "http://github.com/tollmanz/"
+msgstr ""
+
+#. Description of the plugin/theme
+msgid "Adds information about WP scheduled events to Debug Bar."
+msgstr ""
+
+#. Author of the plugin/theme
+msgid "Zack Tollman, Helen Hou-Sandi"
+msgstr ""
+
+#. Author URI of the plugin/theme
+msgid "http://github.com/tollmanz"
+msgstr ""


### PR DESCRIPTION
* Add call to `load_plugin_textdomain()`.
* Fix one wrong language domain pointer.
* Add localization functions around previously untranslatable text.
* Fix translatability of concatenated time-strings + add translators comments for these strings.