### PR TITLE
Cron schedules intervals sorting.

### DIFF
--- a/class-debug-bar-cron.php
+++ b/class-debug-bar-cron.php
@@ -362,7 +362,7 @@ if ( ! class_exists( 'ZT_Debug_Bar_Cron' ) && class_exists( 'Debug_Bar_Panel' ) 
 
 
 			$schedules = wp_get_schedules();
-			uasort($schedules, array($this, 'schedules_sorting'));
+			uasort( $schedules, array( $this, 'schedules_sorting' ) );
 			foreach ( $schedules as $interval_hook => $data ) {
 				$interval = (int) $data['interval'];
 				echo  // WPCS: XSS ok.

--- a/class-debug-bar-cron.php
+++ b/class-debug-bar-cron.php
@@ -362,6 +362,7 @@ if ( ! class_exists( 'ZT_Debug_Bar_Cron' ) && class_exists( 'Debug_Bar_Panel' ) 
 
 
 			$schedules = wp_get_schedules();
+			uasort($schedules, array($this, 'schedules_sorting'));
 			foreach ( $schedules as $interval_hook => $data ) {
 				$interval = (int) $data['interval'];
 				echo  // WPCS: XSS ok.
@@ -380,6 +381,17 @@ if ( ! class_exists( 'ZT_Debug_Bar_Cron' ) && class_exists( 'Debug_Bar_Panel' ) 
 				</table>';
 		}
 
+		/**
+		 * Sorting method for cron scheldules. Order by scheldule interval
+		 *
+		 * @param array $a first element of compasion  pair
+		 * @param array $b second element of compasion  pair
+		 *
+		 * @return int 1 if element $a interval greater then element $b interval, -1  otherwise.
+		 */
+		function schedules_sorting($a, $b){
+			return (int) $a['interval'] > $b['interval'];
+		}
 
 		/**
 		 * Verify if a given timestamp is in the past or the future.

--- a/class-debug-bar-cron.php
+++ b/class-debug-bar-cron.php
@@ -382,10 +382,10 @@ if ( ! class_exists( 'ZT_Debug_Bar_Cron' ) && class_exists( 'Debug_Bar_Panel' ) 
 		}
 
 		/**
-		 * Sorting method for cron scheldules. Order by scheldule interval
+		 * Sorting method for cron scheldules. Order by schedules interval.
 		 *
-		 * @param array $a first element of compasion  pair
-		 * @param array $b second element of compasion  pair
+		 * @param array $a first element of comparison  pair
+		 * @param array $b second element of comparison  pair
 		 *
 		 * @return int 1 if element $a interval greater then element $b interval, -1  otherwise.
 		 */

--- a/class-debug-bar-cron.php
+++ b/class-debug-bar-cron.php
@@ -390,7 +390,7 @@ if ( ! class_exists( 'ZT_Debug_Bar_Cron' ) && class_exists( 'Debug_Bar_Panel' ) 
 		 * @return int 1 if element $a interval greater then element $b interval, -1  otherwise.
 		 */
 		function schedules_sorting($a, $b){
-			return (int) $a['interval'] > $b['interval'];
+			return (int) $a['interval'] > (int) $b['interval'] ? 1 : -1;
 		}
 
 		/**

--- a/class-debug-bar-cron.php
+++ b/class-debug-bar-cron.php
@@ -388,10 +388,11 @@ if ( ! class_exists( 'ZT_Debug_Bar_Cron' ) && class_exists( 'Debug_Bar_Panel' ) 
 		 * @param array $a First element of comparison pair
 		 * @param array $b Second element of comparison pair
 		 *
-		 * @return int 1 if element $a interval greater then element $b interval, -1  otherwise.
+		 * @return int Return 1 if $a argument 'interval' greater then $b argument 'interval', 0 if both intervals equivalent and -1 otherwise.
 		 */
 		function schedules_sorting( $a, $b ){
-			return (int) $a['interval'] > (int) $b['interval'] ? 1 : -1;
+			return (int) $a['interval'] > (int) $b['interval'] ? 1 :
+				( (int) $a['interval'] == (int) $b['interval'] ? 0 : -1 ) ;
 		}
 
 		/**

--- a/class-debug-bar-cron.php
+++ b/class-debug-bar-cron.php
@@ -362,6 +362,7 @@ if ( ! class_exists( 'ZT_Debug_Bar_Cron' ) && class_exists( 'Debug_Bar_Panel' ) 
 
 
 			$schedules = wp_get_schedules();
+			ksort( $schedules );
 			uasort( $schedules, array( $this, 'schedules_sorting' ) );
 			foreach ( $schedules as $interval_hook => $data ) {
 				$interval = (int) $data['interval'];
@@ -384,12 +385,12 @@ if ( ! class_exists( 'ZT_Debug_Bar_Cron' ) && class_exists( 'Debug_Bar_Panel' ) 
 		/**
 		 * Sorting method for cron scheldules. Order by schedules interval.
 		 *
-		 * @param array $a first element of comparison  pair
-		 * @param array $b second element of comparison  pair
+		 * @param array $a First element of comparison pair
+		 * @param array $b Second element of comparison pair
 		 *
 		 * @return int 1 if element $a interval greater then element $b interval, -1  otherwise.
 		 */
-		function schedules_sorting($a, $b){
+		function schedules_sorting( $a, $b ){
 			return (int) $a['interval'] > (int) $b['interval'] ? 1 : -1;
 		}
 


### PR DESCRIPTION

![debug-bar-cron](https://cloud.githubusercontent.com/assets/651824/11658763/b6b67af6-9dc4-11e5-83d1-cc4b1589fad0.png)
In case there is a lot of scheldule intervals. Intervals table can look like a "mess".

Tiny change to fix it. Compassion sorting callback added  as method to be compatible with PHP 5.2 and less hosts.