### PR TITLE
Temporarily change travis WPCS branch to `develop`…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
   # Install CodeSniffer for WordPress Coding Standards checks.
   - git clone --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR
   # Install WordPress Coding Standards.
-  - git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR
+  - git clone -b develop --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR
   # Set install path for WordPress Coding Standards.
   # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
   - $PHPCS_DIR/scripts/phpcs --config-set installed_paths $WPCS_DIR


### PR DESCRIPTION
… as it contains a fix we need.

Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/495