### PR TITLE
Improve admin notice for when Debug Bar is not active

### DIFF
--- a/debug-bar-cron.php
+++ b/debug-bar-cron.php
@@ -35,7 +35,7 @@ if ( ! function_exists( 'debug_bar_cron_has_parent_plugin' ) ) {
 		$file = plugin_basename( __FILE__ );
 
 		if ( is_admin() && ( ! class_exists( 'Debug_Bar' ) && current_user_can( 'activate_plugins' ) ) && is_plugin_active( $file ) ) {
-			add_action( 'admin_notices', create_function( null, 'echo \'<div class="error"><p>\', sprintf( __( \'Activation failed: Debug Bar must be activated to use the <strong>Debug Bar Cron</strong> Plugin. %sVisit your plugins page to activate.\', \'debug-bar-cron\' ), \'<a href="\' . esc_url( admin_url( \'plugins.php#debug-bar\' ) ) . \'">\' ), \'</a></p></div>\';' ) );
+			add_action( 'admin_notices', create_function( null, 'echo \'<div class="error"><p>\', sprintf( __( \'Activation failed: Debug Bar must be activated to use the <strong>Debug Bar Cron</strong> Plugin. %sVisit your plugins page to install & activate.\', \'debug-bar-cron\' ), \'<a href="\' . esc_url( admin_url( \'plugin-install.php?tab=search&s=debug+bar\' ) ) . \'">\' ), \'</a></p></div>\';' ) );
 
 			deactivate_plugins( $file, false, is_network_admin() );
 


### PR DESCRIPTION
Link to the plugin-install page instead which allows people to install *and* activate and doesn't presume they already have the Debug Bar installed, just not active.

Props musamamasood