### PR TITLE
Defer to just in time language loading for WP 4.6+.

### DIFF
--- a/class-zt-debug-bar-cron.php
+++ b/class-zt-debug-bar-cron.php
@@ -108,7 +108,10 @@ if ( ! class_exists( 'ZT_Debug_Bar_Cron' ) && class_exists( 'Debug_Bar_Panel' ) 
 		 * @return void
 		 */
 		public function init() {
-			load_plugin_textdomain( 'debug-bar-cron' );
+			if ( ! function_exists( '_load_textdomain_just_in_time' ) ) {
+				load_plugin_textdomain( 'debug-bar-cron' );
+			}
+
 			$this->title( __( 'Cron', 'debug-bar-cron' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts_styles' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts_styles' ) );

--- a/readme.txt
+++ b/readme.txt
@@ -45,6 +45,7 @@ Yes
 
 = Trunk =
 * Fix compatibility with the [Plugin Dependencies](http://wordpress.org/plugins/plugin-dependencies/) plugin
+* Defer to just in time loading of translations for WP > 4.5.
 
 = 0.1.3 =
 


### PR DESCRIPTION
When WP 4.6 or higher is used, the `load_plugin_textdomain()` function call is no longer necessary.

As this plugin, however, is also compatible with older WP versions and could still be used to debug older installs, don't remove the language loading completely, nor the languages subdirectory (yet).