### PR TITLE
README: Add "Requires PHP" header

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,7 @@ Tags: debug bar, cron
 Requires at least: 3.3
 Tested up to: trunk
 Stable tag: 0.1.3
+Requires PHP: 5.2.4
 
 Debug Bar Cron adds a new panel to Debug Bar that displays information about WP scheduled events.
 


### PR DESCRIPTION
This new header has been soft launched on August 25th 2017.

Refs:
* https://meta.trac.wordpress.org/ticket/2952
* https://meta.trac.wordpress.org/changeset/5841

https://wordpress.org/plugins/developers/readme-validator/