### PR TITLE
Replaces create_function with regular function

### DIFF
--- a/debug-bar-cron.php
+++ b/debug-bar-cron.php
@@ -34,9 +34,7 @@ if ( ! function_exists( 'debug_bar_cron_print_parent_plugin_notice' ) ) {
 	function debug_bar_cron_print_parent_plugin_notice() {
 		$plugin_url = admin_url( 'plugin-install.php?tab=search&s=debug+bar' );
 		echo '<div class="error"><p>';
-		echo 'Activation failed: Debug Bar must be activated to use the <strong>Debug Bar Cron</strong> Plugin. ';
-		sprintf( '<a href="%s">', esc_url( $plugin_url ) );
-		echo 'Visit your plugins page to install & activate.';
+		printf( __( 'Activation failed: Debug Bar must be activated to use the <strong>Debug Bar Cron</strong> Plugin. %sVisit your plugins page to install & activate.', 'debug-bar-cron' ), '<a href="' . esc_url( $plugin_url ) . '">' );
 		echo '</a></p></div>';
 	}
 }

--- a/debug-bar-cron.php
+++ b/debug-bar-cron.php
@@ -27,6 +27,21 @@ if ( ! function_exists( 'add_action' ) ) {
 	exit();
 }
 
+if ( ! function_exists( 'debug_bar_cron_print_parent_plugin_notice' ) ) {
+	/**
+	 * Show admin notice
+	 */
+	function debug_bar_cron_print_parent_plugin_notice() {
+		$plugin_url = admin_url( 'plugin-install.php?tab=search&s=debug+bar' );
+		echo '<div class="error"><p>';
+		echo 'Activation failed: Debug Bar must be activated to use the <strong>Debug Bar Cron</strong> Plugin. ';
+		sprintf( '<a href="%s">', esc_url( $plugin_url ) );
+		echo 'Visit your plugins page to install & activate.';
+		echo '</a></p></div>';
+	}
+}
+
+
 if ( ! function_exists( 'debug_bar_cron_has_parent_plugin' ) ) {
 	/**
 	 * Show admin notice & de-activate if debug-bar plugin not active.
@@ -35,8 +50,7 @@ if ( ! function_exists( 'debug_bar_cron_has_parent_plugin' ) ) {
 		$file = plugin_basename( __FILE__ );
 
 		if ( is_admin() && ( ! class_exists( 'Debug_Bar' ) && current_user_can( 'activate_plugins' ) ) && is_plugin_active( $file ) ) {
-			add_action( 'admin_notices', create_function( null, 'echo \'<div class="error"><p>\', sprintf( __( \'Activation failed: Debug Bar must be activated to use the <strong>Debug Bar Cron</strong> Plugin. %sVisit your plugins page to install & activate.\', \'debug-bar-cron\' ), \'<a href="\' . esc_url( admin_url( \'plugin-install.php?tab=search&s=debug+bar\' ) ) . \'">\' ), \'</a></p></div>\';' ) );
-
+			add_action( 'admin_notices', 'debug_bar_cron_print_parent_plugin_notice' );
 			deactivate_plugins( $file, false, is_network_admin() );
 
 			// Add to recently active plugins list.


### PR DESCRIPTION
[create_function](https://www.php.net/manual/en/function.create-function) is deprecated on  php >7.2.

I replaced it with a regular function while breaking down the string to a more digestible format.

I tried the anonymous function first but those can be not supported on lower php versions so I used to regular function to be on the safer side.

Any feedback is welcome